### PR TITLE
add-fontencoding

### DIFF
--- a/pkg/pdfcpu/validate/font.go
+++ b/pkg/pdfcpu/validate/font.go
@@ -357,7 +357,7 @@ func validateFontEncoding(xRefTable *pdf.XRefTable, d pdf.Dict, dictName string,
 
 	encodings := []string{"MacRomanEncoding", "MacExpertEncoding", "WinAnsiEncoding"}
 	if xRefTable.ValidationMode == pdf.ValidationRelaxed {
-		encodings = append(encodings, "StandardEncoding", "SymbolSetEncoding")
+		encodings = append(encodings, "StandardEncoding", "SymbolSetEncoding", "SymbolEncoding")
 	}
 
 	switch o := o.(type) {


### PR DESCRIPTION
Adds "SymbolEncoding" to relaxed validation encodings alongside the existing "SymbolSetEncoding" type.